### PR TITLE
use scikit instead of torchmcubes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 omegaconf==2.3.0
 Pillow==10.1.0
 einops==0.7.0
-git+https://github.com/tatsy/torchmcubes.git
+scikit-image
 transformers==4.35.0
 trimesh==4.0.5
 rembg


### PR DESCRIPTION
Increase usability by using scikit-image instead of the old torchmcubes. This makes the project much easier to install and test.