### PR TITLE
Implement texturing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ python run.py examples/chair.png --output-dir output/
 ```
 This will save the reconstructed 3D model to `output/`. You can also specify more than one image path separated by spaces. The default options takes about **6GB VRAM** for a single image input.
 
+If you would like to output a texture instead of vertex colors, use the `--bake-texture` option. You may also use `--texture-resolution` to specify the resolution in pixels of the output texture.
+
 For detailed usage of this script, use `python run.py --help`.
 
 ### Local Gradio App

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -60,7 +60,7 @@ def preprocess(input_image, do_remove_background, foreground_ratio):
 
 def generate(image, mc_resolution, formats=["obj", "glb"]):
     scene_codes = model(image, device=device)
-    mesh = model.extract_mesh(scene_codes, resolution=mc_resolution)[0]
+    mesh = model.extract_mesh(scene_codes, True, resolution=mc_resolution)[0]
     mesh = to_gradio_3d_orientation(mesh)
     rv = []
     for format in formats:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ rembg
 huggingface-hub
 imageio[ffmpeg]
 gradio
+xatlas==0.0.9
+moderngl==5.10.0

--- a/tsr/bake_texture.py
+++ b/tsr/bake_texture.py
@@ -1,0 +1,170 @@
+import numpy as np
+import torch
+import xatlas
+import trimesh
+import moderngl
+from PIL import Image
+
+
+def make_atlas(mesh, texture_resolution, texture_padding):
+    atlas = xatlas.Atlas()
+    atlas.add_mesh(mesh.vertices, mesh.faces)
+    options = xatlas.PackOptions()
+    options.resolution = texture_resolution
+    options.padding = texture_padding
+    options.bilinear = True
+    atlas.generate(pack_options=options)
+    vmapping, indices, uvs = atlas[0]
+    return {
+        "vmapping": vmapping,
+        "indices": indices,
+        "uvs": uvs,
+    }
+
+
+def rasterize_position_atlas(
+    mesh, atlas_vmapping, atlas_indices, atlas_uvs, texture_resolution, texture_padding
+):
+    ctx = moderngl.create_context(standalone=True)
+    basic_prog = ctx.program(
+        vertex_shader="""
+            #version 330
+            in vec2 in_uv;
+            in vec3 in_pos;
+            out vec3 v_pos;
+            void main() {
+                v_pos = in_pos;
+                gl_Position = vec4(in_uv * 2.0 - 1.0, 0.0, 1.0);
+            }
+        """,
+        fragment_shader="""
+            #version 330
+            in vec3 v_pos;
+            out vec4 o_col;
+            void main() {
+                o_col = vec4(v_pos, 1.0);
+            }
+        """,
+    )
+    gs_prog = ctx.program(
+        vertex_shader="""
+            #version 330
+            in vec2 in_uv;
+            in vec3 in_pos;
+            out vec3 vg_pos;
+            void main() {
+                vg_pos = in_pos;
+                gl_Position = vec4(in_uv * 2.0 - 1.0, 0.0, 1.0);
+            }
+        """,
+        geometry_shader="""
+            #version 330
+            uniform float u_resolution;
+            uniform float u_dilation;
+            layout (triangles) in;
+            layout (triangle_strip, max_vertices = 12) out;
+            in vec3 vg_pos[];
+            out vec3 vf_pos;
+            void lineSegment(int aidx, int bidx) {
+                vec2 a = gl_in[aidx].gl_Position.xy;
+                vec2 b = gl_in[bidx].gl_Position.xy;
+                vec3 aCol = vg_pos[aidx];
+                vec3 bCol = vg_pos[bidx];
+
+                vec2 dir = normalize((b - a) * u_resolution);
+                vec2 offset = vec2(-dir.y, dir.x) * u_dilation / u_resolution;
+
+                gl_Position = vec4(a + offset, 0.0, 1.0);
+                vf_pos = aCol;
+                EmitVertex();
+                gl_Position = vec4(a - offset, 0.0, 1.0);
+                vf_pos = aCol;
+                EmitVertex();
+                gl_Position = vec4(b + offset, 0.0, 1.0);
+                vf_pos = bCol;
+                EmitVertex();
+                gl_Position = vec4(b - offset, 0.0, 1.0);
+                vf_pos = bCol;
+                EmitVertex();
+            }
+            void main() {
+                lineSegment(0, 1);
+                lineSegment(1, 2);
+                lineSegment(2, 0);
+                EndPrimitive();
+            }
+        """,
+        fragment_shader="""
+            #version 330
+            in vec3 vf_pos;
+            out vec4 o_col;
+            void main() {
+                o_col = vec4(vf_pos, 1.0);
+            }
+        """,
+    )
+    uvs = atlas_uvs.flatten().astype("f4")
+    pos = mesh.vertices[atlas_vmapping].flatten().astype("f4")
+    indices = atlas_indices.flatten().astype("i4")
+    vbo_uvs = ctx.buffer(uvs)
+    vbo_pos = ctx.buffer(pos)
+    ibo = ctx.buffer(indices)
+    vao_content = [
+        vbo_uvs.bind("in_uv", layout="2f"),
+        vbo_pos.bind("in_pos", layout="3f"),
+    ]
+    basic_vao = ctx.vertex_array(basic_prog, vao_content, ibo)
+    gs_vao = ctx.vertex_array(gs_prog, vao_content, ibo)
+    fbo = ctx.framebuffer(
+        color_attachments=[
+            ctx.texture((texture_resolution, texture_resolution), 4, dtype="f4")
+        ]
+    )
+    fbo.use()
+    fbo.clear(0.0, 0.0, 0.0, 0.0)
+    gs_prog["u_resolution"].value = texture_resolution
+    gs_prog["u_dilation"].value = texture_padding
+    gs_vao.render()
+    basic_vao.render()
+
+    fbo_bytes = fbo.color_attachments[0].read()
+    fbo_np = np.frombuffer(fbo_bytes, dtype="f4").reshape(
+        texture_resolution, texture_resolution, 4
+    )
+    return fbo_np
+
+
+def positions_to_colors(model, scene_code, positions_texture, texture_resolution):
+    positions = torch.tensor(positions_texture.reshape(-1, 4)[:, :-1])
+    with torch.no_grad():
+        queried_grid = model.renderer.query_triplane(
+            model.decoder,
+            positions,
+            scene_code,
+        )
+    rgb_f = queried_grid["color"].numpy().reshape(-1, 3)
+    rgba_f = np.insert(rgb_f, 3, positions_texture.reshape(-1, 4)[:, -1], axis=1)
+    rgba_f[rgba_f[:, -1] == 0.0] = [0, 0, 0, 0]
+    return rgba_f.reshape(texture_resolution, texture_resolution, 4)
+
+
+def bake_texture(mesh, model, scene_code, texture_resolution):
+    texture_padding = round(max(2, texture_resolution / 256))
+    atlas = make_atlas(mesh, texture_resolution, texture_padding)
+    positions_texture = rasterize_position_atlas(
+        mesh,
+        atlas["vmapping"],
+        atlas["indices"],
+        atlas["uvs"],
+        texture_resolution,
+        texture_padding,
+    )
+    colors_texture = positions_to_colors(
+        model, scene_code, positions_texture, texture_resolution
+    )
+    return {
+        "vmapping": atlas["vmapping"],
+        "indices": atlas["indices"],
+        "uvs": atlas["uvs"],
+        "colors": colors_texture,
+    }

--- a/tsr/system.py
+++ b/tsr/system.py
@@ -168,7 +168,7 @@ class TSR(BaseModule):
             return
         self.isosurface_helper = MarchingCubeHelper(resolution)
 
-    def extract_mesh(self, scene_codes, resolution: int = 256, threshold: float = 25.0):
+    def extract_mesh(self, scene_codes, has_vertex_color, resolution: int = 256, threshold: float = 25.0):
         self.set_marching_cubes_resolution(resolution)
         meshes = []
         for scene_code in scene_codes:
@@ -188,16 +188,18 @@ class TSR(BaseModule):
                 self.isosurface_helper.points_range,
                 (-self.renderer.cfg.radius, self.renderer.cfg.radius),
             )
-            with torch.no_grad():
-                color = self.renderer.query_triplane(
-                    self.decoder,
-                    v_pos,
-                    scene_code,
-                )["color"]
+            color = None
+            if has_vertex_color:
+                with torch.no_grad():
+                    color = self.renderer.query_triplane(
+                        self.decoder,
+                        v_pos,
+                        scene_code,
+                    )["color"]
             mesh = trimesh.Trimesh(
                 vertices=v_pos.cpu().numpy(),
                 faces=t_pos_idx.cpu().numpy(),
-                vertex_colors=color.cpu().numpy(),
+                vertex_colors=color.cpu().numpy() if has_vertex_color else None,
             )
             meshes.append(mesh)
         return meshes


### PR DESCRIPTION
Merged in the texturing implementation from my other repo **TripoSR-Bake**, per #76 
Unfortunately, due to the high-poly and sometimes not completely smooth nature of the marching cubes output, the generated atlas often has many islands and thus there are seams if you zoom in close enough to the mesh.
Note that OpenGL is required for baking the texture atlas; see also https://github.com/iffyloop/TripoSR-Bake/issues/1#issuecomment-2041681886